### PR TITLE
don't call releaseConnection b/c it executes a rollback

### DIFF
--- a/dataAccess.js
+++ b/dataAccess.js
@@ -301,7 +301,9 @@ DataAccess.prototype.commitTransaction = function (connection, callback) {
 			deferred.reject(errorObj);
 		}
 		else {
-			releaseConnection(connection);
+			connection.release();
+			delete connection.transactional;
+      			connection.isReleased = true;
 			deferred.resolve(connection.results);
 		}
 	});


### PR DESCRIPTION
don't call releaseConnection because it executes a rollback on a transaction after it has already been committed