### PR TITLE
only reset password if param sent

### DIFF
--- a/common/admin_1_0_0.js
+++ b/common/admin_1_0_0.js
@@ -289,19 +289,6 @@ Admin.prototype.patch = {
 		}
 
 		var password = req.body.password;
-		if (utilities.isNullOrUndefined(password)) {
-			var errorObj = new ErrorObj(500,
-										'ad0007',
-										__filename,
-										'user',
-										'cannot delete password',
-										'Cannot delete password');
-			deferred.reject(errorObj);
-
-			deferred.promise.nodeify(callback);
-			return deferred.promise;
-		}
-
 		var first = (req.body.first === null) ? '' : req.body.first;
 		var last = (req.body.last === null) ? '' : req.body.last;
 		var roles = (req.body.roles === null) ? ['default-user'] : req.body.roles;
@@ -359,7 +346,7 @@ Admin.prototype.patch = {
 			}
 		})
 		.spread(function(existingUser, buf) {
-			if(buf !== undefined) {
+			if(buf !== undefined && !utilities.isNullOrUndefined(password)) {
 				var salt = buf.toString('hex');
 				var saltedPassword = password + salt;
 				var hashedPassword = crypto.createHash('sha256').update(saltedPassword).digest('hex');


### PR DESCRIPTION
This is solve the issue of backstrap erroring any time someone attempts to edit a user's information/role via the GUI while also maintaining that a password can't be deleted. 

If no new password is sent as a parameter the existing password remains in place. 