### PR TITLE
make serviceCall optional and default to index call setting

### DIFF
--- a/BackstrapServer.js
+++ b/BackstrapServer.js
@@ -139,6 +139,9 @@ settings.init(config.s3.bucket, 'Settings.json', useRemoteSettings)
 		// ---------------------------------------------------------------------------------
 		app.get('/:area/:controller/:serviceCall/:version?', function (req, res) {
 			requestPipeline(req, res, 'GET');
+    });
+    app.get('/:area/:controller?', function (req, res) {
+			requestPipeline(req, res, 'GET');
 		});
 		// ---------------------------------------------------------------------------------
 		// ---------------------------------------------------------------------------------
@@ -148,6 +151,9 @@ settings.init(config.s3.bucket, 'Settings.json', useRemoteSettings)
 		// ---------------------------------------------------------------------------------
 		app.post('/:area/:controller/:serviceCall/:version?', function (req, res) {
 			requestPipeline(req, res, 'POST');
+    });
+    app.post('/:area/:controller?', function (req, res) {
+			requestPipeline(req, res, 'POST');
 		});
 		// ---------------------------------------------------------------------------------
 		// ---------------------------------------------------------------------------------
@@ -155,6 +161,9 @@ settings.init(config.s3.bucket, 'Settings.json', useRemoteSettings)
 		// PUTS
 		// ---------------------------------------------------------------------------------
 		app.put('/:area/:controller/:serviceCall/:version?', function (req, res) {
+			requestPipeline(req, res, 'PUT');
+    });
+    app.put('/:area/:controller?', function (req, res) {
 			requestPipeline(req, res, 'PUT');
 		});
 		// ---------------------------------------------------------------------------------
@@ -164,6 +173,9 @@ settings.init(config.s3.bucket, 'Settings.json', useRemoteSettings)
 		// ---------------------------------------------------------------------------------
 		app.patch('/:area/:controller/:serviceCall/:version?', function (req, res) {
 			requestPipeline(req, res, 'PATCH');
+    });
+    app.patch('/:area/:controller?', function (req, res) {
+			requestPipeline(req, res, 'PATCH');
 		});
 		// ---------------------------------------------------------------------------------
 		// ---------------------------------------------------------------------------------
@@ -171,6 +183,9 @@ settings.init(config.s3.bucket, 'Settings.json', useRemoteSettings)
 		// DELETES
 		// ---------------------------------------------------------------------------------
 		app.delete('/:area/:controller/:serviceCall/:version?', function (req, res) {
+			requestPipeline(req, res, 'DELETE');
+    });
+    app.delete('/:area/:controller?', function (req, res) {
 			requestPipeline(req, res, 'DELETE');
 		});
 		// ---------------------------------------------------------------------------------
@@ -229,7 +244,14 @@ function requestPipeline(req, res, verb) {
   var params = req.params;
   var area = params.area;
   var controller = params.controller;
-  var serviceCall = params.serviceCall;
+  var serviceCall
+  if(!params.serviceCall) {
+    serviceCall = settings.data.index_service_call;
+  }
+  else{
+    serviceCall = params.serviceCall;
+  }
+  
   var args;
   if(verb.toLowerCase() === 'get') {
     args = req.query;

--- a/Settings.json
+++ b/Settings.json
@@ -4,6 +4,7 @@
 	"timeout": 120,
 	"server_port": 3000,
   "servers": [],
+  "index_service_call": "index",
   "access_logging": false,
   "session_logging": false,
   "log_rotation_period": 90,


### PR DESCRIPTION
@jonnyb-lookfar 
I have updated backstrapserver.js to service calls with only an area and controller in the call. 

If there is no service call it pulls the default/index service call name from the settings file attribute `index_service_call` which defaults to "index" but it can be changed to whatever the api creator wants.