### PR TITLE
add option to respond using res.download for serving file downloads

### DIFF
--- a/BackstrapServer.js
+++ b/BackstrapServer.js
@@ -406,7 +406,18 @@ function requestPipeline(req, res, verb) {
       accessLog.write(logEntry);
     }
 
-    res.status(200).send(results);
+    if(results.express_download === true){
+      if(results.download_name){
+        res.status(200).download(results.download_path, results.download_name);
+      }
+      else {
+        res.status(200).download(results.download_path);
+      }
+    }
+    else {
+      res.status(200).send(results);
+    }
+    
   })
   .fail(function (err) {
     if (err.http_status == null) {


### PR DESCRIPTION
allows you to make use of native express file download serving by structuring a resolve object from your endpoint with the following paramters:

var resolve_object = {
    express_download: true,
    download_name: file_data.attachment_name,
    download_path: '~/../../efs_data_internal/claims/documents/' + file_data.file_path
};

deferred.resolve(resolve_object);